### PR TITLE
fix: avoid text wrapping and open links in a new tab 

### DIFF
--- a/src/pages/LoveNote.astro
+++ b/src/pages/LoveNote.astro
@@ -17,6 +17,6 @@ if ('abcghijkl'.includes(firstChar)) {
 <div class="message">
   <div class="comment">{Astro.props.message}</div>
   <img alt="" crossorigin="anonymous" src={`https://ghavatars.staticblitz.com/${username}.png?size=90`} />
-  <div class="from">Published with <span class="emoji">{emoji}</span> by <a href={`https://github.com/${username}`}>{username}</a></div>
+  <div class="from">Published with <span class="emoji">{emoji}</span> by <a href={`https://github.com/${username}`} target="_blank" rel="noreferrer noopener">{username}</a></div>
 </div>
 

--- a/src/pages/LoveNote.scss
+++ b/src/pages/LoveNote.scss
@@ -16,6 +16,7 @@
     .from {
         position:absolute;
         bottom:-25px;
+        width: max-content;
         font-size:12px;
         display:block;
         vertical-align: middle;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,7 +43,7 @@ import DeveloperLove from './DeveloperLove.astro';
 		<h1>I love <span class="flow">Codeflow</span>.</h1>
 		<div>
 			<a href="https://pr.new/stackblitz/ilovecodeflow.com/edit/main/src/pages/DeveloperLove.astro" class="btn-push">Add your name!</a>
-			<a class="docs" href="https://developer.stackblitz.com/codeflow/what-is-codeflow">
+			<a class="docs" href="https://developer.stackblitz.com/codeflow/what-is-codeflow" target="_blank" rel="noreferrer noopener">
 				Learn more
 			</a>
 		</div>


### PR DESCRIPTION
- Added `target="_blank"` to open the links in a new tab
- The "from" message doesn't show up nicely when a message is too short (I hope people will write a lots of love to codeflow but just in case!!). As a quick fix, I added `width: max-content` so the content will not wrap.
- Edited in Codeflow IDE 🎉

before:
<img width="303" alt="Screenshot 2022-10-11 at 15 22 15" src="https://user-images.githubusercontent.com/3702771/195111698-46237c31-2e0c-4cca-9bcb-3c99d4f26262.png">

after:
<img width="360" alt="Screenshot 2022-10-11 at 15 21 49" src="https://user-images.githubusercontent.com/3702771/195111726-a9918245-1264-4465-bc22-b5c516bcfaef.png">
