### PR TITLE
Use loading=lazy on avatars

### DIFF
--- a/src/pages/LoveNote.astro
+++ b/src/pages/LoveNote.astro
@@ -16,7 +16,7 @@ if ('abcghijkl'.includes(firstChar)) {
 
 <div class="message">
   <div class="comment">{Astro.props.message}</div>
-  <img alt="" crossorigin="anonymous" src={`https://ghavatars.staticblitz.com/${username}.png?size=90`} />
+  <img alt="" crossorigin="anonymous" loading="lazy" src={`https://ghavatars.staticblitz.com/${username}.png?size=90`} />
   <div class="from">Published with <span class="emoji">{emoji}</span> by <a href={`https://github.com/${username}`} target="_blank" rel="noreferrer noopener">{username}</a></div>
 </div>
 


### PR DESCRIPTION
As more people add their message to ilovecodeflow.com (yay!), the browser ends up with a lot of images to load all at once.

This PR adds `loading="lazy"` to images to let the browser load images when they enter the viewport (usually with some offset: browsers tend to load images when they are 1000px away from the viewport or less).

In my tests the images above the fold seem to load quicker (they are not competing with other images below the fold), and when scrolling images may appear while scrolling or after a short delay.